### PR TITLE
Fix weekly report summary display

### DIFF
--- a/Reports/2025/06/2025-06-08.html
+++ b/Reports/2025/06/2025-06-08.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 선물 시장 주간 동향",
+    "subtitle": "Coffee Futures Market Weekly Update",
+    "date": "2025-06-08",
+    "summary": "커피 선물이 금요일 브라질 수확 진행과 베트남 수출 증가로 하락세를 보였습니다. 7월 아라비카 커피(KCN25)는 1.70포인트(-0.47%) 하락했으며, 7월 ICE 로부스타 커피(RMN25)는 153포인트(-3.33%) 급락했습니다.",
+    "tags": ["주간동향", "브라질수확", "베트남수출", "커피선물", "가격하락", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/Reports/2025/06/2025-06-09.html
+++ b/Reports/2025/06/2025-06-09.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 선물 시장 주간 동향",
+    "subtitle": "Coffee Futures Market Weekly Update",
+    "date": "2025-06-09",
+    "summary": "커피 선물이 금요일 브라질 수확 진행과 베트남 수출 증가로 하락세를 보였습니다. 7월 아라비카 커피(KCN25)는 1.70포인트(-0.47%) 하락했으며, 7월 ICE 로부스타 커피(RMN25)는 153포인트(-3.33%) 급락했습니다.",
+    "tags": ["주간동향", "브라질수확", "베트남수출", "커피선물", "가격하락", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/Reports/2025/06/2025-06-13.html
+++ b/Reports/2025/06/2025-06-13.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 선물 시장 주간 동향",
+    "subtitle": "Coffee Futures Market Weekly Update",
+    "date": "2025-06-13",
+    "summary": "커피 선물이 브라질 수확 진행과 베트남 수출 증가로 중요한 지지선을 테스트하고 있습니다. 7월 아라비카 커피(KCN25)는 347.80센트에서 거래되며 전일 대비 2.85센트(-0.81%) 하락했습니다.",
+    "tags": ["주간동향", "지지선테스트", "브라질수확", "베트남수출", "가격하락", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/Reports/2025/06/2025-06-14.html
+++ b/Reports/2025/06/2025-06-14.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "단기 커피 선물 가격 전망 및 방향성 점검",
+    "subtitle": "Short-term Coffee Futures Price Forecast",
+    "date": "2025-06-14",
+    "summary": "KCN25는 349.90센트로 +0.60% 상승하며 1차 지지선(344.83센트)을 상회 회복했습니다. 단기적으로는 브라질 수확 진행(28% 완료)과 투기적 숏 포지션(-37,065계약)이 하방 압력으로 작용하나, 구조적으로는 글로벌 아라비카 적자 850만 백과 25년 만에 최저 재고가 강세 요인으로 작용합니다.",
+    "tags": ["가격전망", "기술적분석", "지지선", "브라질수확", "투기포지션", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>In-depth 단기 커피 선물 가격 전망 및 방향성 점검</title>

--- a/Reports/2025/06/2025-06-21.html
+++ b/Reports/2025/06/2025-06-21.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 선물 시장 주간 동향",
+    "subtitle": "Coffee Futures Market Weekly Update",
+    "date": "2025-06-21",
+    "summary": "커피 선물이 브라질 수확 진행과 글로벌 공급 확대 전망으로 급락세를 지속하고 있습니다. 9월 아라비카 커피(KCU25)는 315.05센트로 1월 이후 최저치를 경신했으며, 로부스타는 13개월 최저치로 하락했습니다.",
+    "tags": ["주간동향", "가격급락", "브라질수확", "최저치경신", "공급확대", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/Reports/2025/06/2025-06-24.html
+++ b/Reports/2025/06/2025-06-24.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 가격, 폭풍 전야",
+    "subtitle": "Coffee Futures Market Update",
+    "date": "2025-06-24",
+    "summary": "아라비카 커피 시장은 강력한 강세 요인과 잠재적 약세 리스크가 충돌하며 높은 수준의 변동성을 예고하고 있습니다. 전 세계 커피 재고가 역사적 최저 수준에 근접하고 있으며, 단기 가격 전망은 310-390센트입니다.",
+    "tags": ["가격전망", "변동성", "재고부족", "수급전망", "시장분석", "폭풍전야"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/Reports/2025/06/2025-06-28.html
+++ b/Reports/2025/06/2025-06-28.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 선물 시장 주간 동향",
+    "subtitle": "Coffee Futures Market Weekly Update",
+    "date": "2025-06-28",
+    "summary": "커피 선물이 브라질 수확 가속화와 충분한 공급 전망으로 급락세를 이어가고 있습니다. 9월 아라비카 커피(KCU25)는 303.75센트로 전주 대비 3.5% 하락하며 6.75개월 만에 최저치를 기록했습니다.",
+    "tags": ["주간동향", "가격급락", "최저치경신", "브라질수확", "공급전망", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/Reports/2025/07/2025-07-04.html
+++ b/Reports/2025/07/2025-07-04.html
@@ -1,6 +1,15 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <!--REPORT_META
+{
+    "title": "커피 선물 시장 주간 동향",
+    "subtitle": "Coffee Futures Market Weekly Update",
+    "date": "2025-07-04",
+    "summary": "커피 선물이 브라질 수확 가속화와 충분한 공급 전망으로 하락세를 이어가고 있습니다. 9월 아라비카 커피(KCU25)는 289.90센트로 전주 대비 4.56% 하락했습니다. 브라질의 커피 수확이 순조롭게 진행되고 인도네시아 로부스타 수출이 급증하는 등 공급 증가 요인이 시장을 압박하고 있습니다.",
+    "tags": ["주간동향", "가격하락", "브라질수확", "공급증가", "시장약세", "시장분석"]
+}
+REPORT_META-->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>커피 선물 시장 주간 동향 (Coffee Futures Market Update)</title>

--- a/weekly-report.html
+++ b/weekly-report.html
@@ -367,11 +367,45 @@
                 title = titleElement.textContent.trim();
             }
             
-            // 요약 추출
+            // 요약 추출 - 여러 방법으로 시도
             let summary = '';
-            const summaryElement = doc.querySelector('.highlight p') || doc.querySelector('.summary') || doc.querySelector('p');
-            if (summaryElement) {
-                summary = summaryElement.textContent.trim().substring(0, 200);
+            
+            // 1. 주요 헤드라인 찾기
+            const headlineElement = doc.querySelector('h2');
+            if (headlineElement && headlineElement.textContent.includes('주요 헤드라인')) {
+                const nextElement = headlineElement.nextElementSibling;
+                if (nextElement && nextElement.tagName === 'P') {
+                    summary = nextElement.textContent.trim();
+                }
+            }
+            
+            // 2. highlight 클래스 내용 찾기
+            if (!summary) {
+                const highlightElement = doc.querySelector('.highlight p, .highlight li');
+                if (highlightElement) {
+                    summary = highlightElement.textContent.trim();
+                }
+            }
+            
+            // 3. main-story 클래스 내용 찾기
+            if (!summary) {
+                const mainStoryElement = doc.querySelector('.main-story p');
+                if (mainStoryElement) {
+                    summary = mainStoryElement.textContent.trim();
+                }
+            }
+            
+            // 4. 첫 번째 p 태그 찾기
+            if (!summary) {
+                const firstParagraph = doc.querySelector('p');
+                if (firstParagraph) {
+                    summary = firstParagraph.textContent.trim();
+                }
+            }
+            
+            // summary가 너무 길면 자르기
+            if (summary && summary.length > 200) {
+                summary = summary.substring(0, 197) + '...';
             }
             
             // 태그 추출
@@ -380,11 +414,16 @@
                 .filter(tag => tag && tag.length > 0)
                 .slice(0, 6);
             
+            // 태그가 없으면 기본 태그 추가
+            if (tags.length === 0) {
+                tags.push('주간동향', '커피선물', '시장분석');
+            }
+            
             return {
-                title: title || '커피 시장 동향',
+                title: title || '커피 선물 시장 주간 동향',
                 subtitle: '',
                 date: defaultDate,
-                summary: summary || '',
+                summary: summary || '커피 선물 시장의 주간 동향을 분석한 리포트입니다.',
                 tags: tags
             };
         }
@@ -441,7 +480,14 @@
                     const htmlContent = await response.text();
                     const metadata = extractReportMetadata(htmlContent, filePath);
                     
-                    if (metadata && metadata.title.includes('커피 선물 시장 주간 동향')) {
+                    // 주간 동향 리포트 필터링 - 더 유연한 조건
+                    if (metadata && (
+                        metadata.title.includes('커피 선물 시장 주간 동향') ||
+                        metadata.title.includes('Coffee Futures Market Weekly Update') ||
+                        metadata.title.includes('Coffee Futures Market Update') ||
+                        (metadata.title.includes('주간') && metadata.title.includes('동향')) ||
+                        metadata.tags.includes('주간동향')
+                    )) {
                         weeklyReports.push({
                             ...metadata,
                             link: filePath,


### PR DESCRIPTION
<!-- Enhance weekly report display by adding metadata to specific report files and improving summary extraction and filtering logic in `weekly-report.html`. -->
The `weekly-report.html` page was failing to display correct summaries for reports between 2025-06-08 and 2025-07-04 because some reports lacked explicit metadata blocks. Additionally, the JavaScript logic for extracting summaries from legacy reports and filtering "weekly update" reports was too restrictive, leading to generic titles being shown instead of actual report summaries. This PR addresses these issues by adding the missing metadata and making the extraction/filtering more robust.

---

[Open in Web](https://cursor.com/agents?id=bc-881c0329-03d6-40ef-8ef8-9e688155266d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-881c0329-03d6-40ef-8ef8-9e688155266d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)