### PR TITLE
Verify and enhance major country export import data

### DIFF
--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -437,10 +437,10 @@
         
         <div class="fundamentals-grid">
             <div class="fundamental-card">
-                <span class="card-icon">🌍</span>
+                <span class="card-icon">🌱</span>
                 <h3 class="card-title">글로벌 생산량</h3>
                 <div class="card-content">
-                    <p>주요 생산국의 커피 생산량과 작황 현황을 모니터링합니다.</p>
+                    <p>전 세계 커피 생산량과 주요 생산국의 작황을 모니터링합니다.</p>
                     <div class="stat-box">
                         <div class="stat-value">170M</div>
                         <div class="stat-label">2024/25 예상 생산량 (bags)</div>
@@ -471,150 +471,6 @@
                     </div>
                 </div>
             </div>
-            
-            <div class="fundamental-card">
-                <span class="card-icon">🌦️</span>
-                <h3 class="card-title">기후 영향</h3>
-                <div class="card-content">
-                    <p>엘니뇨/라니냐 등 기후 패턴이 커피 생산에 미치는 영향을 평가합니다.</p>
-                    <div class="stat-box">
-                        <div class="stat-value">라니냐</div>
-                        <div class="stat-label">2025년 예상 패턴</div>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="fundamental-card">
-                <span class="card-icon">💰</span>
-                <h3 class="card-title">생산 비용</h3>
-                <div class="card-content">
-                    <p>비료, 노동력, 운송비 등 생산 비용 변화를 모니터링합니다.</p>
-                    <div class="stat-box">
-                        <div class="stat-value">+15%</div>
-                        <div class="stat-label">전년 대비 비용 상승</div>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="fundamental-card">
-                <span class="card-icon">🚢</span>
-                <h3 class="card-title">수출입 동향</h3>
-                <div class="card-content">
-                    <p>주요 수출국과 수입국의 무역 흐름을 추적합니다.</p>
-                    <div class="stat-box">
-                        <div class="stat-value">145M</div>
-                        <div class="stat-label">연간 교역량 (bags)</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <div class="supply-demand-section">
-            <h2 class="section-title">
-                ⚖️ 글로벌 수급 밸런스
-            </h2>
-            <table class="balance-table">
-                <thead>
-                    <tr>
-                        <th>항목</th>
-                        <th>2023/24</th>
-                        <th>2024/25(E)</th>
-                        <th>변화</th>
-                        <th>트렌드</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td><strong>생산량</strong></td>
-                        <td>168M bags</td>
-                        <td>170M bags</td>
-                        <td>+1.2%</td>
-                        <td><span class="trend-indicator trend-up">↑ 증가</span></td>
-                    </tr>
-                    <tr>
-                        <td><strong>소비량</strong></td>
-                        <td>171M bags</td>
-                        <td>175M bags</td>
-                        <td>+2.3%</td>
-                        <td><span class="trend-indicator trend-up">↑ 증가</span></td>
-                    </tr>
-                    <tr>
-                        <td><strong>수급 차이</strong></td>
-                        <td>-3M bags</td>
-                        <td>-5M bags</td>
-                        <td>-66.7%</td>
-                        <td><span class="trend-indicator trend-down">↓ 적자 확대</span></td>
-                    </tr>
-                    <tr>
-                        <td><strong>기말 재고</strong></td>
-                        <td>32M bags</td>
-                        <td>27M bags</td>
-                        <td>-15.6%</td>
-                        <td><span class="trend-indicator trend-down">↓ 감소</span></td>
-                    </tr>
-                    <tr>
-                        <td><strong>재고/소비 비율</strong></td>
-                        <td>18.7%</td>
-                        <td>15.4%</td>
-                        <td>-3.3%p</td>
-                        <td><span class="trend-indicator trend-down">↓ 타이트</span></td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        
-        <div class="supply-demand-section">
-            <h2 class="section-title">
-                🌎 주요 생산국 현황
-            </h2>
-            <table class="balance-table">
-                <thead>
-                    <tr>
-                        <th>국가</th>
-                        <th>2024/25 생산량</th>
-                        <th>세계 점유율</th>
-                        <th>주요 품종</th>
-                        <th>수확 시기</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td><strong>브라질</strong></td>
-                        <td>65M bags</td>
-                        <td>38.2%</td>
-                        <td>아라비카/로부스타</td>
-                        <td>5-9월</td>
-                    </tr>
-                    <tr>
-                        <td><strong>베트남</strong></td>
-                        <td>28M bags</td>
-                        <td>16.5%</td>
-                        <td>로부스타</td>
-                        <td>10-3월</td>
-                    </tr>
-                    <tr>
-                        <td><strong>콜롬비아</strong></td>
-                        <td>12M bags</td>
-                        <td>7.1%</td>
-                        <td>아라비카</td>
-                        <td>연중</td>
-                    </tr>
-                    <tr>
-                        <td><strong>인도네시아</strong></td>
-                        <td>10M bags</td>
-                        <td>5.9%</td>
-                        <td>로부스타/아라비카</td>
-                        <td>4-9월</td>
-                    </tr>
-                    <tr>
-                        <td><strong>에티오피아</strong></td>
-                        <td>8M bags</td>
-                        <td>4.7%</td>
-                        <td>아라비카</td>
-                        <td>10-1월</td>
-                    </tr>
-                </tbody>
-            </table>
         </div>
         
         <!-- 주요국 수출입 동향 섹션 -->

--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -423,6 +423,7 @@
             }
         }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <div class="container">
@@ -572,7 +573,81 @@
     </div>
 
     <script>
-        // 공통 차트 옵션
+        // 구글 시트 URL 설정
+        const EXPORT_IMPORT_SHEETS = {
+            brazilUsExport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=0',
+            koreaBrazilImport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=1897130496'
+        };
+
+        // CSV 파싱 함수
+        function parseCSV(csvText) {
+            const lines = csvText.split('\n');
+            const result = [];
+            
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i].trim();
+                if (line) {
+                    const cells = line.split(',');
+                    result.push(cells);
+                }
+            }
+            
+            return result;
+        }
+
+        // 데이터 처리 함수
+        function processExportImportData(csvData, isUsExport = false) {
+            const dataByYear = {};
+            
+            // 헤더 제외하고 데이터 처리
+            const dataRows = csvData.slice(1);
+            
+            dataRows.forEach(row => {
+                if (row[0] && row[1]) {
+                    const [year, month] = row[0].split('-');
+                    if (!dataByYear[year]) {
+                        dataByYear[year] = new Array(12).fill(null);
+                    }
+                    let value = parseFloat(row[1]);
+                    
+                    // 미국 수출 데이터는 10만톤 단위로 변환
+                    if (isUsExport) {
+                        value = value / 100000;
+                    }
+                    
+                    dataByYear[year][parseInt(month) - 1] = value;
+                }
+            });
+            
+            // YoY 변화율 자동 계산
+            const years = Object.keys(dataByYear).sort();
+            const yoyChangeRate = [];
+            
+            if (years.length >= 2) {
+                const currentYear = years[years.length - 1];
+                const previousYear = years[years.length - 2];
+                
+                for (let i = 0; i < 12; i++) {
+                    const current = dataByYear[currentYear][i];
+                    const previous = dataByYear[previousYear][i];
+                    
+                    if (current !== null && previous !== null && previous !== 0) {
+                        const change = ((current - previous) / previous) * 100;
+                        yoyChangeRate.push(parseFloat(change.toFixed(1)));
+                    } else {
+                        yoyChangeRate.push(null);
+                    }
+                }
+            }
+            
+            return {
+                data2024: dataByYear['2024'] || new Array(12).fill(null),
+                data2025: dataByYear['2025'] || new Array(12).fill(null),
+                yoyChangeRate: yoyChangeRate
+            };
+        }
+
+        // 차트 공통 옵션
         const commonChartOptions = {
             responsive: true,
             maintainAspectRatio: false,
@@ -632,26 +707,10 @@
         // 월 라벨
         const months = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
         
-        // 미국향 수출 데이터 (10만톤 단위로 변환)
-        const usExportData2024 = [2.24, 2.17, 2.09, 2.54, 2.44, 2.04, 2.03, 2.07, 2.43, 2.80, 2.86, 2.02];
-        const usExportData2025 = [2.46, 1.73, 2.20, 1.74, 1.71, 1.34, null, null, null, null, null, null];
-        const usYoyChangeRate = [9.8, -20.3, 5.3, -31.5, -29.9, -34.3];
-        
-        // 한국 수입 데이터 (톤 단위 그대로)
-        const koreaImportData2024 = [6889.81, 4185.71, 3503.19, 5721.36, 4445.76, 4980.18, 5330.91, 6420.28, 4327.47, 5144.04, 2457.25, 5752.22];
-        const koreaImportData2025 = [3829.50, 7009.28, 5072.39, 5672.69, 5779.15, 4815.05, 4033.01, null, null, null, null, null];
-        
-        // 한국 YoY 변화율 계산
-        const koreaYoyChangeRate = [];
-        for (let i = 0; i < 7; i++) {
-            if (koreaImportData2025[i] !== null && koreaImportData2024[i] !== null) {
-                const changeRate = ((koreaImportData2025[i] - koreaImportData2024[i]) / koreaImportData2024[i]) * 100;
-                koreaYoyChangeRate.push(parseFloat(changeRate.toFixed(1)));
-            } else {
-                koreaYoyChangeRate.push(null);
-            }
-        }
-        
+        // 차트 인스턴스 저장
+        let usChart = null;
+        let koreaChart = null;
+
         // 그라데이션 생성 함수
         function createGradient(ctx, color1, color2) {
             const gradient = ctx.createLinearGradient(0, 0, 0, 400);
@@ -659,22 +718,20 @@
             gradient.addColorStop(1, color2);
             return gradient;
         }
-        
-        // 미국향 수출 차트 생성
-        const usCtx = document.getElementById('usExportChart').getContext('2d');
-        
-        // 그라데이션 생성
-        const us2024Gradient = createGradient(usCtx, '#d5dbdb', '#bdc3c7');
-        const us2025Gradient = createGradient(usCtx, '#A0522D', '#6B2C0F');
-        
-        const usChart = new Chart(usCtx, {
-            type: 'bar',
-            data: {
+
+        // 차트 생성/업데이트 함수
+        function createOrUpdateCharts(usExportData, koreaImportData) {
+            // 미국향 수출 차트
+            const usCtx = document.getElementById('usExportChart').getContext('2d');
+            const us2024Gradient = createGradient(usCtx, '#d5dbdb', '#bdc3c7');
+            const us2025Gradient = createGradient(usCtx, '#A0522D', '#6B2C0F');
+            
+            const usChartData = {
                 labels: months,
                 datasets: [
                     {
                         label: '2024년',
-                        data: usExportData2024,
+                        data: usExportData.data2024,
                         backgroundColor: us2024Gradient,
                         borderColor: '#95a5a6',
                         borderWidth: 1,
@@ -683,7 +740,7 @@
                     },
                     {
                         label: '2025년',
-                        data: usExportData2025,
+                        data: usExportData.data2025,
                         backgroundColor: us2025Gradient,
                         borderColor: '#8B4513',
                         borderWidth: 1,
@@ -692,14 +749,12 @@
                     },
                     {
                         label: '전년 동기 대비 변화율',
-                        data: [...usYoyChangeRate, null, null, null, null, null, null],
+                        data: usExportData.yoyChangeRate,
                         type: 'line',
-                        borderColor: function(context) {
-                            return '#FF6B35'; // 모든 점을 주황색으로 (음수가 많음)
-                        },
+                        borderColor: '#FF6B35',
                         backgroundColor: 'rgba(255, 107, 53, 0.2)',
                         borderWidth: 4,
-                        pointBackgroundColor: usYoyChangeRate.map(rate => rate >= 0 ? '#3498db' : '#FF6B35'),
+                        pointBackgroundColor: usExportData.yoyChangeRate.map(rate => rate >= 0 ? '#3498db' : '#FF6B35'),
                         pointBorderColor: '#ffffff',
                         pointBorderWidth: 3,
                         pointRadius: 8,
@@ -707,72 +762,68 @@
                         yAxisID: 'y1',
                         tension: 0.3,
                         fill: false,
-                        order: 1,
-                        segment: {
-                            borderColor: function(ctx) {
-                                const current = usYoyChangeRate[ctx.p0DataIndex];
-                                const next = usYoyChangeRate[ctx.p1DataIndex];
-                                if (current >= 0 && next >= 0) return '#3498db';
-                                if (current < 0 && next < 0) return '#FF6B35';
-                                return '#95a5a6'; // 교차점
-                            }
-                        }
+                        order: 1
                     }
                 ]
-            },
-            options: {
-                ...commonChartOptions,
-                plugins: {
-                    ...commonChartOptions.plugins,
-                    tooltip: {
-                        callbacks: {
-                            label: function(context) {
-                                if (context.datasetIndex === 2) {
-                                    return `변화율: ${context.parsed.y}%`;
-                                } else {
-                                    return `${context.dataset.label}: ${context.parsed.y}십만톤`;
+            };
+
+            if (usChart) {
+                usChart.data = usChartData;
+                usChart.update();
+            } else {
+                usChart = new Chart(usCtx, {
+                    type: 'bar',
+                    data: usChartData,
+                    options: {
+                        ...commonChartOptions,
+                        plugins: {
+                            ...commonChartOptions.plugins,
+                            tooltip: {
+                                callbacks: {
+                                    label: function(context) {
+                                        if (context.datasetIndex === 2) {
+                                            return `변화율: ${context.parsed.y}%`;
+                                        } else {
+                                            return `${context.dataset.label}: ${context.parsed.y}십만톤`;
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            ...commonChartOptions.scales,
+                            y: {
+                                ...commonChartOptions.scales.y,
+                                title: {
+                                    display: true,
+                                    text: '수출량 (10만톤)',
+                                    font: {
+                                        size: 12,
+                                        weight: '600'
+                                    }
+                                },
+                                ticks: {
+                                    callback: function(value) {
+                                        return value.toFixed(1);
+                                    }
                                 }
                             }
                         }
                     }
-                },
-                scales: {
-                    ...commonChartOptions.scales,
-                    y: {
-                        ...commonChartOptions.scales.y,
-                        title: {
-                            display: true,
-                            text: '수출량 (10만톤)',
-                            font: {
-                                size: 12,
-                                weight: '600'
-                            }
-                        },
-                        ticks: {
-                            callback: function(value) {
-                                return value.toFixed(1);
-                            }
-                        }
-                    }
-                }
+                });
             }
-        });
-        
-        // 한국 수입 차트 생성
-        const koreaCtx = document.getElementById('koreaImportChart').getContext('2d');
-        
-        // 그라데이션 생성
-        const korea2024Gradient = createGradient(koreaCtx, '#d5dbdb', '#bdc3c7');
-        const korea2025Gradient = createGradient(koreaCtx, '#A0522D', '#6B2C0F');
-        
-        const koreaChart = new Chart(koreaCtx, {
-            type: 'bar',
-            data: {
+
+            // 한국 수입 차트
+            const koreaCtx = document.getElementById('koreaImportChart').getContext('2d');
+            const korea2024Gradient = createGradient(koreaCtx, '#d5dbdb', '#bdc3c7');
+            const korea2025Gradient = createGradient(koreaCtx, '#A0522D', '#6B2C0F');
+            
+            const koreaChartData = {
                 labels: months,
                 datasets: [
                     {
                         label: '2024년',
-                        data: koreaImportData2024,
+                        data: koreaImportData.data2024,
                         backgroundColor: korea2024Gradient,
                         borderColor: '#95a5a6',
                         borderWidth: 1,
@@ -781,7 +832,7 @@
                     },
                     {
                         label: '2025년',
-                        data: koreaImportData2025,
+                        data: koreaImportData.data2025,
                         backgroundColor: korea2025Gradient,
                         borderColor: '#8B4513',
                         borderWidth: 1,
@@ -790,14 +841,12 @@
                     },
                     {
                         label: '전년 동기 대비 변화율',
-                        data: [...koreaYoyChangeRate, null, null, null, null, null],
+                        data: koreaImportData.yoyChangeRate,
                         type: 'line',
-                        borderColor: function(context) {
-                            return '#3498db'; // 기본색 (양수가 많음)
-                        },
+                        borderColor: '#3498db',
                         backgroundColor: 'rgba(52, 152, 219, 0.2)',
                         borderWidth: 4,
-                        pointBackgroundColor: koreaYoyChangeRate.map(rate => rate >= 0 ? '#3498db' : '#FF6B35'),
+                        pointBackgroundColor: koreaImportData.yoyChangeRate.map(rate => rate >= 0 ? '#3498db' : '#FF6B35'),
                         pointBorderColor: '#ffffff',
                         pointBorderWidth: 3,
                         pointRadius: 8,
@@ -805,64 +854,117 @@
                         yAxisID: 'y1',
                         tension: 0.3,
                         fill: false,
-                        order: 1,
-                        segment: {
-                            borderColor: function(ctx) {
-                                const current = koreaYoyChangeRate[ctx.p0DataIndex];
-                                const next = koreaYoyChangeRate[ctx.p1DataIndex];
-                                if (current >= 0 && next >= 0) return '#3498db';
-                                if (current < 0 && next < 0) return '#FF6B35';
-                                return '#95a5a6'; // 교차점
-                            }
-                        }
+                        order: 1
                     }
                 ]
-            },
-            options: {
-                ...commonChartOptions,
-                plugins: {
-                    ...commonChartOptions.plugins,
-                    tooltip: {
-                        callbacks: {
-                            label: function(context) {
-                                if (context.datasetIndex === 2) {
-                                    return `변화율: ${context.parsed.y}%`;
-                                } else {
-                                    return `${context.dataset.label}: ${context.parsed.y.toLocaleString()}kg`;
+            };
+
+            if (koreaChart) {
+                koreaChart.data = koreaChartData;
+                koreaChart.update();
+            } else {
+                koreaChart = new Chart(koreaCtx, {
+                    type: 'bar',
+                    data: koreaChartData,
+                    options: {
+                        ...commonChartOptions,
+                        plugins: {
+                            ...commonChartOptions.plugins,
+                            tooltip: {
+                                callbacks: {
+                                    label: function(context) {
+                                        if (context.datasetIndex === 2) {
+                                            return `변화율: ${context.parsed.y}%`;
+                                        } else {
+                                            return `${context.dataset.label}: ${context.parsed.y.toLocaleString()}톤`;
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        scales: {
+                            ...commonChartOptions.scales,
+                            y: {
+                                ...commonChartOptions.scales.y,
+                                title: {
+                                    display: true,
+                                    text: '수입량 (톤)',
+                                    font: {
+                                        size: 12,
+                                        weight: '600'
+                                    }
+                                },
+                                ticks: {
+                                    callback: function(value) {
+                                        return value.toLocaleString();
+                                    }
                                 }
                             }
                         }
                     }
-                },
-                scales: {
-                    ...commonChartOptions.scales,
-                    y: {
-                        ...commonChartOptions.scales.y,
-                        title: {
-                            display: true,
-                            text: '수입량 (kg)',
-                            font: {
-                                size: 12,
-                                weight: '600'
-                            }
-                        },
-                        ticks: {
-                            callback: function(value) {
-                                return value.toLocaleString();
-                            }
-                        }
-                    }
+                });
+            }
+        }
+
+        // 데이터 로드 및 차트 생성
+        async function loadAndCreateCharts() {
+            try {
+                // 로딩 표시
+                document.querySelector('.chart-wrapper').style.opacity = '0.5';
+                
+                // 브라질 수출 데이터 로드
+                const usExportResponse = await fetch(EXPORT_IMPORT_SHEETS.brazilUsExport);
+                const usExportCsv = await usExportResponse.text();
+                const usExportCsvData = parseCSV(usExportCsv);
+                const usExportData = processExportImportData(usExportCsvData, true);
+                
+                // 한국 수입 데이터 로드
+                const koreaImportResponse = await fetch(EXPORT_IMPORT_SHEETS.koreaBrazilImport);
+                const koreaImportCsv = await koreaImportResponse.text();
+                const koreaImportCsvData = parseCSV(koreaImportCsv);
+                const koreaImportData = processExportImportData(koreaImportCsvData, false);
+                
+                // 차트 생성/업데이트
+                createOrUpdateCharts(usExportData, koreaImportData);
+                
+                // 한국 평균 변화율 업데이트
+                updateKoreaAvgChange(koreaImportData);
+                
+                // 로딩 완료
+                document.querySelector('.chart-wrapper').style.opacity = '1';
+                
+            } catch (error) {
+                console.error('Error loading data:', error);
+                // 에러 시 기본 데이터로 표시
+                const defaultData = {
+                    data2024: new Array(12).fill(0),
+                    data2025: new Array(12).fill(null),
+                    yoyChangeRate: new Array(12).fill(null)
+                };
+                createOrUpdateCharts(defaultData, defaultData);
+            }
+        }
+
+        // 페이지 로드 시 차트 생성
+        document.addEventListener('DOMContentLoaded', function() {
+            loadAndCreateCharts();
+            
+            // 5분마다 데이터 새로고침
+            setInterval(loadAndCreateCharts, 5 * 60 * 1000);
+        });
+
+        // 한국 평균 변화율 업데이트 함수
+        function updateKoreaAvgChange(koreaImportData) {
+            const koreaYoyChangeRate = koreaImportData.yoyChangeRate;
+            const validRates = koreaYoyChangeRate.filter(rate => rate !== null);
+            if (validRates.length > 0) {
+                const koreaAvgChangeRate = validRates.reduce((sum, rate) => sum + rate, 0) / validRates.length;
+                const element = document.getElementById('koreaAvgChange');
+                if (element) {
+                    element.textContent = (koreaAvgChangeRate >= 0 ? '+' : '') + koreaAvgChangeRate.toFixed(1) + '%';
                 }
             }
-        });
-        
-        // 한국 평균 변화율 업데이트
-        const koreaAvgChangeRate = koreaYoyChangeRate.filter(rate => rate !== null).reduce((sum, rate) => sum + rate, 0) / koreaYoyChangeRate.filter(rate => rate !== null).length;
-        document.getElementById('koreaAvgChange').textContent = (koreaAvgChangeRate >= 0 ? '+' : '') + koreaAvgChangeRate.toFixed(1) + '%';
-        
-        // 차트 애니메이션
-        usChart.update('active');
-        koreaChart.update('active');
+        }
     </script>
 </body>
 </html>

--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -430,48 +430,8 @@
             ← 메인 페이지로 돌아가기
         </a>
         
-        <div class="header">
-            <h1>📊 Fundamentals</h1>
-            <p class="subtitle">커피 시장 펀더멘털 분석</p>
-        </div>
-        
-        <div class="fundamentals-grid">
-            <div class="fundamental-card">
-                <span class="card-icon">🌱</span>
-                <h3 class="card-title">글로벌 생산량</h3>
-                <div class="card-content">
-                    <p>전 세계 커피 생산량과 주요 생산국의 작황을 모니터링합니다.</p>
-                    <div class="stat-box">
-                        <div class="stat-value">170M</div>
-                        <div class="stat-label">2024/25 예상 생산량 (bags)</div>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="fundamental-card">
-                <span class="card-icon">☕</span>
-                <h3 class="card-title">글로벌 소비량</h3>
-                <div class="card-content">
-                    <p>전 세계 커피 소비 트렌드와 주요 소비국의 수요 변화를 추적합니다.</p>
-                    <div class="stat-box">
-                        <div class="stat-value">175M</div>
-                        <div class="stat-label">2024/25 예상 소비량 (bags)</div>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="fundamental-card">
-                <span class="card-icon">📦</span>
-                <h3 class="card-title">재고 수준</h3>
-                <div class="card-content">
-                    <p>주요 소비국과 생산국의 커피 재고 현황을 분석합니다.</p>
-                    <div class="stat-box">
-                        <div class="stat-value">25년 최저</div>
-                        <div class="stat-label">현재 재고 수준</div>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <h1 class="page-title">☕ Coffee Market Fundamentals</h1>
+        <p class="page-subtitle">커피 시장의 핵심 펀더멘털 지표와 실시간 데이터를 제공합니다</p>
         
         <!-- 주요국 수출입 동향 섹션 -->
         <div class="dashboard-container">

--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -453,7 +453,7 @@
                     </div>
                     
                     <div class="chart-container">
-                        <canvas id="usExportChart"></canvas>
+                        <canvas id="brazilExportChart"></canvas>
                     </div>
                     
                     <div class="legend-custom">
@@ -575,7 +575,7 @@
     <script>
         // 구글 시트 URL 설정
         const EXPORT_IMPORT_SHEETS = {
-            brazilUsExport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=0',
+            brazilTotalExport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=0',
             koreaBrazilImport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=1'
         };
 
@@ -708,7 +708,7 @@
         const months = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
         
         // 차트 인스턴스 저장
-        let usChart = null;
+        let brazilChart = null;
         let koreaChart = null;
 
         // 그라데이션 생성 함수
@@ -720,19 +720,19 @@
         }
 
         // 차트 생성/업데이트 함수
-        function createOrUpdateCharts(usExportData, koreaImportData) {
-            // 미국향 수출 차트
-            const usCtx = document.getElementById('usExportChart').getContext('2d');
-            const us2024Gradient = createGradient(usCtx, '#d5dbdb', '#bdc3c7');
-            const us2025Gradient = createGradient(usCtx, '#A0522D', '#6B2C0F');
+        function createOrUpdateCharts(brazilExportData, koreaImportData) {
+            // 브라질 전체 수출 차트
+            const brazilCtx = document.getElementById('brazilExportChart').getContext('2d');
+            const brazil2024Gradient = createGradient(brazilCtx, '#d5dbdb', '#bdc3c7');
+            const brazil2025Gradient = createGradient(brazilCtx, '#A0522D', '#6B2C0F');
             
-            const usChartData = {
+            const brazilChartData = {
                 labels: months,
                 datasets: [
                     {
                         label: '2024년',
-                        data: usExportData.data2024,
-                        backgroundColor: us2024Gradient,
+                        data: brazilExportData.data2024,
+                        backgroundColor: brazil2024Gradient,
                         borderColor: '#95a5a6',
                         borderWidth: 1,
                         yAxisID: 'y',
@@ -740,8 +740,8 @@
                     },
                     {
                         label: '2025년',
-                        data: usExportData.data2025,
-                        backgroundColor: us2025Gradient,
+                        data: brazilExportData.data2025,
+                        backgroundColor: brazil2025Gradient,
                         borderColor: '#8B4513',
                         borderWidth: 1,
                         yAxisID: 'y',
@@ -749,12 +749,12 @@
                     },
                     {
                         label: '전년 동기 대비 변화율',
-                        data: usExportData.yoyChangeRate,
+                        data: brazilExportData.yoyChangeRate,
                         type: 'line',
                         borderColor: '#FF6B35',
                         backgroundColor: 'rgba(255, 107, 53, 0.2)',
                         borderWidth: 4,
-                        pointBackgroundColor: usExportData.yoyChangeRate.map(rate => rate >= 0 ? '#3498db' : '#FF6B35'),
+                        pointBackgroundColor: brazilExportData.yoyChangeRate.map(rate => rate >= 0 ? '#3498db' : '#FF6B35'),
                         pointBorderColor: '#ffffff',
                         pointBorderWidth: 3,
                         pointRadius: 8,
@@ -767,13 +767,13 @@
                 ]
             };
 
-            if (usChart) {
-                usChart.data = usChartData;
-                usChart.update();
+            if (brazilChart) {
+                brazilChart.data = brazilChartData;
+                brazilChart.update();
             } else {
-                usChart = new Chart(usCtx, {
+                brazilChart = new Chart(brazilCtx, {
                     type: 'bar',
-                    data: usChartData,
+                    data: brazilChartData,
                     options: {
                         ...commonChartOptions,
                         plugins: {
@@ -915,11 +915,11 @@
                     wrapper.style.opacity = '0.5';
                 });
                 
-                // 브라질 수출 데이터 로드
-                const usExportResponse = await fetch(EXPORT_IMPORT_SHEETS.brazilUsExport);
-                const usExportCsv = await usExportResponse.text();
-                const usExportCsvData = parseCSV(usExportCsv);
-                const usExportData = processExportImportData(usExportCsvData, true);
+                // 브라질 전체 수출 데이터 로드
+                const brazilExportResponse = await fetch(EXPORT_IMPORT_SHEETS.brazilTotalExport);
+                const brazilExportCsv = await brazilExportResponse.text();
+                const brazilExportCsvData = parseCSV(brazilExportCsv);
+                const brazilExportData = processExportImportData(brazilExportCsvData, true);
                 
                 // 한국 수입 데이터 로드
                 const koreaImportResponse = await fetch(EXPORT_IMPORT_SHEETS.koreaBrazilImport);
@@ -928,7 +928,7 @@
                 const koreaImportData = processExportImportData(koreaImportCsvData, false);
                 
                 // 차트 생성/업데이트
-                createOrUpdateCharts(usExportData, koreaImportData);
+                createOrUpdateCharts(brazilExportData, koreaImportData);
                 
                 // 한국 평균 변화율 업데이트
                 updateKoreaAvgChange(koreaImportData);

--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -576,7 +576,7 @@
         // 구글 시트 URL 설정
         const EXPORT_IMPORT_SHEETS = {
             brazilUsExport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=0',
-            koreaBrazilImport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=1897130496'
+            koreaBrazilImport: 'https://docs.google.com/spreadsheets/d/1Q0lYxDRF39TqMzKIo7w9qLbXmLRfMuyxqacPxPArNVQ/export?format=csv&gid=1'
         };
 
         // CSV 파싱 함수
@@ -910,7 +910,10 @@
         async function loadAndCreateCharts() {
             try {
                 // 로딩 표시
-                document.querySelector('.chart-wrapper').style.opacity = '0.5';
+                const chartWrappers = document.querySelectorAll('.chart-wrapper');
+                chartWrappers.forEach(wrapper => {
+                    wrapper.style.opacity = '0.5';
+                });
                 
                 // 브라질 수출 데이터 로드
                 const usExportResponse = await fetch(EXPORT_IMPORT_SHEETS.brazilUsExport);
@@ -931,7 +934,9 @@
                 updateKoreaAvgChange(koreaImportData);
                 
                 // 로딩 완료
-                document.querySelector('.chart-wrapper').style.opacity = '1';
+                chartWrappers.forEach(wrapper => {
+                    wrapper.style.opacity = '1';
+                });
                 
             } catch (error) {
                 console.error('Error loading data:', error);


### PR DESCRIPTION
Remove fictional data sections and integrate Google Sheets for export/import charts on the Fundamentals page to use fact-based, real-time data.

The initial Fundamentals page contained several sections with placeholder/fictional data. This PR removes all such non-fact-based data and integrates a Google Sheet as the data source for the "Brazil Total Green Bean Export Volume" and "Korea's Brazil Green Bean Import Volume" charts, allowing for dynamic and verifiable data display.

---

[Open in Web](https://cursor.com/agents?id=bc-becbf8f0-abc9-4f2c-be39-a353616c8061) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-becbf8f0-abc9-4f2c-be39-a353616c8061) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)