### PR TITLE
Fundamental 페이지 돌아가기 버튼 위치 수정

### DIFF
--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -29,6 +29,7 @@
             text-align: center;
             margin-bottom: 50px;
             padding: 40px 20px;
+            margin-top: 20px;
         }
         
         h1 {
@@ -440,13 +441,14 @@
 </head>
 <body>
     <div class="container">
+        <a href="../index.html" class="back-button">
+            <span>←</span>
+            <span>메인으로 돌아가기</span>
+        </a>
+        
         <div class="header">
             <h1>Coffee Market Fundamentals</h1>
             <p class="subtitle">커피 시장의 기초 데이터와 핵심 지표를 실시간으로 확인하세요</p>
-            <a href="../index.html" class="back-button">
-                <span>←</span>
-                <span>메인으로 돌아가기</span>
-            </a>
         </div>
         
         <!-- 주요국 수출입 동향 섹션 -->


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move 'back to main' button on fundamental page to match other pages' top-left position.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---

[Open in Web](https://cursor.com/agents?id=bc-1cff3226-b4b5-49f0-a43a-be12e89b48cb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1cff3226-b4b5-49f0-a43a-be12e89b48cb) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)