### PR TITLE
Fix in-depth menu display for uploaded file

### DIFF
--- a/in-depth-analysis.html
+++ b/in-depth-analysis.html
@@ -312,7 +312,9 @@
         // 동적으로 리포트 파일 목록 가져오기
         async function getReportFiles() {
             try {
-                const response = await fetch('scan-reports.php');
+                // 캐시 방지를 위한 타임스탬프 추가
+                const timestamp = new Date().getTime();
+                const response = await fetch(`scan-reports.php?t=${timestamp}`);
                 if (response.ok) {
                     const data = await response.json();
                     if (data.success && data.files) {
@@ -326,6 +328,7 @@
             
             // 폴백: 하드코딩된 파일 목록
             return [
+                'Reports/2025/07/2025-07-29.html',
                 'Reports/2025/07/2025-07-26.html',       
                 'Reports/2025/07/2025-07-25.html',       
                 'Reports/2025/07/2025-07-19.html',   
@@ -468,6 +471,7 @@
             
             // 동적으로 파일 목록 가져오기
             const reportFiles = await getReportFiles();
+            console.log('로드된 전체 파일 목록:', reportFiles);
             const analysisReports = [];
             
             for (const filePath of reportFiles) {
@@ -480,11 +484,14 @@
                     
                     // "커피 선물 시장 주간 동향"을 제외한 모든 리포트
                     if (metadata && !metadata.title.includes('커피 선물 시장 주간 동향')) {
+                        console.log(`심층 분석 리포트 추가: ${filePath} - ${metadata.title}`);
                         analysisReports.push({
                             ...metadata,
                             link: filePath,
                             displayDate: formatKoreanDate(metadata.date)
                         });
+                    } else if (metadata) {
+                        console.log(`주간 동향 리포트로 제외: ${filePath} - ${metadata.title}`);
                     }
                 } catch (error) {
                     console.error(`로딩 실패 ${filePath}:`, error);

--- a/index.html
+++ b/index.html
@@ -1204,7 +1204,8 @@
             
             try {
                 // PHP 스크립트를 통해 Reports 폴더 동적 스캔
-                const response = await fetch('scan-reports.php');
+                const timestamp = new Date().getTime();
+                const response = await fetch(`scan-reports.php?t=${timestamp}`);
                 if (response.ok) {
                     const data = await response.json();
                     if (data.success && data.files) {

--- a/scan-reports.php
+++ b/scan-reports.php
@@ -1,6 +1,9 @@
 <?php
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: *');
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
 
 // Reports 디렉토리 경로
 $reportsDir = 'Reports';

--- a/weekly-report.html
+++ b/weekly-report.html
@@ -320,7 +320,9 @@
         // 동적으로 리포트 파일 목록 가져오기
         async function getReportFiles() {
             try {
-                const response = await fetch('scan-reports.php');
+                // 캐시 방지를 위한 타임스탬프 추가
+                const timestamp = new Date().getTime();
+                const response = await fetch(`scan-reports.php?t=${timestamp}`);
                 if (response.ok) {
                     const data = await response.json();
                     if (data.success && data.files) {
@@ -334,6 +336,7 @@
             
             // 폴백: 하드코딩된 파일 목록
             return [
+                'Reports/2025/07/2025-07-29.html',
                 'Reports/2025/07/2025-07-26.html',       
                 'Reports/2025/07/2025-07-25.html',       
                 'Reports/2025/07/2025-07-19.html',   


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add 2025-07-29.html to in-depth and weekly report menus and implement cache-busting to ensure proper display.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The 2025-07-29.html report was not appearing in the in-depth menu due to its absence in the hardcoded fallback lists and potential browser caching issues preventing dynamic updates. Cache-busting measures were added to address this.

---
<a href="https://cursor.com/background-agent?bcId=bc-51d84a36-de31-4511-83d8-2c9480a3f384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51d84a36-de31-4511-83d8-2c9480a3f384">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>