### PR TITLE
Adjust indepth and fundamentals menu subheading font size

### DIFF
--- a/fundamentals/fundamentals.html
+++ b/fundamentals/fundamentals.html
@@ -33,7 +33,7 @@
         }
         
         h1 {
-            font-size: 3em;
+            font-size: 2.2em;
             color: #8B4513;
             margin-bottom: 20px;
             font-weight: 700;
@@ -204,7 +204,7 @@
         }
         
         .dashboard-title {
-            font-size: 2.5em;
+            font-size: 1.8em;
             font-weight: 700;
             color: #0f172a;
             margin-bottom: 12px;
@@ -408,7 +408,7 @@
             }
             
             h1 {
-                font-size: 2.2em;
+                font-size: 1.8em;
             }
             
             .fundamentals-grid {

--- a/in-depth-analysis.html
+++ b/in-depth-analysis.html
@@ -28,7 +28,7 @@
         }
         
         h1 {
-            font-size: 3em;
+            font-size: 2.2em;
             color: #8B4513;
             margin-bottom: 20px;
             font-weight: 700;
@@ -68,7 +68,7 @@
         }
         
         .info-title {
-            font-size: 2em;
+            font-size: 1.5em;
             color: #8B4513;
             margin-bottom: 20px;
             display: flex;
@@ -260,7 +260,7 @@
             }
             
             h1 {
-                font-size: 2.2em;
+                font-size: 1.8em;
                 line-height: 1.3;
             }
             
@@ -281,7 +281,7 @@
         
         @media (max-width: 480px) {
             h1 {
-                font-size: 1.8em;
+                font-size: 1.5em;
             }
             
             .subtitle {


### PR DESCRIPTION
Reduce font sizes for main and section titles in Indepth and Fundamentals pages to improve readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ac09df8-15fb-4cd7-a338-8d8db9d5aee1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ac09df8-15fb-4cd7-a338-8d8db9d5aee1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>