### PR TITLE
Fix broken webpage functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -1306,7 +1306,7 @@
                 console.log('동적 스캔 실패, 하드코딩된 목록 사용:', error);
                 // 폴백: 하드코딩된 파일 목록
                 reportFiles = [
-                    'Reports/2025/07/2025-08-02.html'
+                    'Reports/2025/08/2025-08-02.html',
                     'Reports/2025/07/2025-07-29.html',
                     'Reports/2025/07/2025-07-26.html',       
                     'Reports/2025/07/2025-07-25.html',       
@@ -1577,18 +1577,24 @@
             ];
         }
 
-        // 메인 리포트 초기화 함수 (JSON 제거 버전)
+        // 메인 리포트 초기화 함수
         async function initializeReports() {
             try {
                 console.log('리포트 초기화 시작...');
                 
-                // HTML 파일에서 직접 로드 (JSON 폴백 제거)
-                let reports = await loadReportsFromFiles();
-                console.log('파일에서 로드된 리포트:', reports.length);
+                // 먼저 JSON 파일에서 로드 시도
+                let reports = await loadReportsFromJSON();
+                console.log('JSON에서 로드된 리포트:', reports.length);
                 
-                // 로드 실패 시 기본 데이터 사용
+                // JSON 로드 실패 시 HTML 파일에서 직접 로드
                 if (reports.length === 0) {
-                    console.log('파일 로드 실패, 기본 데이터 사용');
+                    reports = await loadReportsFromFiles();
+                    console.log('파일에서 로드된 리포트:', reports.length);
+                }
+                
+                // 모든 로드 실패 시 기본 데이터 사용
+                if (reports.length === 0) {
+                    console.log('모든 로드 실패, 기본 데이터 사용');
                     reports = getDefaultReports();
                 }
                 


### PR DESCRIPTION
Fix syntax error and add JSON fallback for report loading to make the page functional without PHP.

The page was not working due to a JavaScript syntax error (missing comma) and a dependency on a PHP script (`scan-reports.php`) which was not available. This PR fixes the syntax error and modifies the report loading logic to first attempt loading from `reports.json` (a static file) before falling back to direct HTML file loading, ensuring the page can display reports even without a PHP server.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f2cbfdb-84e8-4e93-89fd-a158430178bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f2cbfdb-84e8-4e93-89fd-a158430178bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>