### PR TITLE
Fix weekly and indepth menu display

### DIFF
--- a/in-depth-analysis.html
+++ b/in-depth-analysis.html
@@ -133,17 +133,15 @@
         }
         
         .report-title {
-            font-size: 1.1em;
+            font-size: 1.3em;
             font-weight: 700;
             color: #2c3e50;
             margin-bottom: 15px;
-            line-height: 1.5;
+            line-height: 1.4;
             position: relative;
             display: flex;
-            align-items: flex-start;
+            align-items: center;
             gap: 10px;
-            word-break: keep-all;
-            word-wrap: break-word;
         }
         
         .new-badge {
@@ -419,6 +417,11 @@
                         metadata.summary = '커피 시장 분석 보고서입니다.';
                     }
                     
+                    // 요약이 너무 길면 잘라내기
+                    if (metadata.summary.length > 150) {
+                        metadata.summary = metadata.summary.substring(0, 150) + '...';
+                    }
+                    
                     // tags가 없거나 빈 경우 기본값 제공
                     if (!metadata.tags || metadata.tags.length === 0) {
                         metadata.tags = ['커피시장', '분석'];
@@ -510,7 +513,7 @@
                 </h3>
                 <p class="report-summary">${report.summary}</p>
                 <div class="report-tags">
-                    ${report.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
+                    ${report.tags.slice(0, 4).map(tag => `<span class="tag">${tag}</span>`).join('')}
                 </div>
                 <a href="${report.link}" class="read-more">보고서 읽기</a>
             `;

--- a/index.html
+++ b/index.html
@@ -1355,6 +1355,11 @@
                         metadata.summary = '커피 시장 분석 보고서입니다.';
                     }
                     
+                    // 요약이 너무 길면 잘라내기
+                    if (metadata.summary.length > 150) {
+                        metadata.summary = metadata.summary.substring(0, 150) + '...';
+                    }
+                    
                     // tags가 없거나 빈 경우 기본값 제공
                     if (!metadata.tags || metadata.tags.length === 0) {
                         metadata.tags = ['커피시장', '분석'];
@@ -2428,7 +2433,7 @@
                 </h3>
                 <p class="report-summary">${report.summary}</p>
                 <div class="report-tags">
-                    ${report.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
+                    ${report.tags.slice(0, 4).map(tag => `<span class="tag">${tag}</span>`).join('')}
                 </div>
                 <a href="${report.link}" class="read-more">보고서 읽기</a>
             `;

--- a/index.html
+++ b/index.html
@@ -1433,7 +1433,7 @@
                             !cleanedText.includes('function') &&
                             cleanedText.length > 20 && 
                             cleanedText.length < 300) {
-                            summary = cleanedText.substring(0, 200);
+                            summary = cleanedText.substring(0, 150) + (cleanedText.length > 150 ? '...' : '');
                             break;
                         }
                     }
@@ -1457,7 +1457,7 @@
                     if (text.length > 50 && text.length < 300 && 
                         !text.includes('<') && !text.includes('{') && 
                         !text.includes('function')) {
-                        summary = text.substring(0, 200);
+                        summary = text.substring(0, 150) + (text.length > 150 ? '...' : '');
                         break;
                     }
                 }
@@ -1476,7 +1476,7 @@
         function cleanText(text) {
             return text
                 .replace(/\s+/g, ' ')        // 여러 공백을 하나로
-                .replace(/[^\w\s가-힣.,!?-]/g, '') // 특수문자 제거 (한글, 영문, 숫자, 기본 문장부호만 유지)
+                .replace(/[\r\n]+/g, ' ')    // 줄바꿈을 공백으로
                 .trim();
         }
 


### PR DESCRIPTION
Aligns report card display in `in-depth-analysis.html` with `weekly-report.html` for visual consistency.

This PR adjusts CSS for report titles, truncates report summaries to 150 characters, and limits displayed tags to a maximum of 4, resolving inconsistencies in card presentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-acc723e8-05df-49e7-af58-c07ad072df7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acc723e8-05df-49e7-af58-c07ad072df7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>