### PR TITLE
Fix weekly and in-depth report loading issue

### DIFF
--- a/in-depth-analysis.html
+++ b/in-depth-analysis.html
@@ -698,29 +698,44 @@
             const loadingSpinner = document.getElementById('loadingSpinner');
             
             try {
-                // 파일 기반 로딩 시도
-                let allReports = await loadReportsFromFiles();
+                // JSON 파일을 우선적으로 시도
+                let allReports = await loadReportsFromJSON();
                 
-                // 파일 로딩 실패 시 JSON 폴백
+                // JSON 로딩 실패 시 파일 기반 로딩 시도
                 if (allReports.length === 0) {
-                    allReports = await loadReportsFromJSON();
+                    allReports = await loadReportsFromFiles();
                 }
                 
-                // 심층 분석 리포트만 필터링 - 주간 동향이 아닌 리포트
+                // 심층 분석 리포트만 필터링 - 개선된 필터링 로직
                 const analysisReports = allReports.filter(report => {
                     // type이 in-depth로 명시된 경우
                     if (report.type === 'in-depth') return true;
                     
-                    // 제목에 "커피 시장 주간 동향"이 포함되지 않은 경우
-                    return report.title && !(
+                    // 주간 동향이 아닌 리포트들을 심층 분석으로 분류
+                    const isWeekly = report.title && (
+                        report.title.includes('주간 동향') ||
                         report.title.includes('커피 시장 주간 동향') ||
                         report.title.includes('커피 선물 시장 주간 동향') ||
                         report.title === '커피 선물 시장 주간 동향'
                     );
+                    
+                    // 태그에 주간 관련 키워드가 있는지 확인
+                    const hasWeeklyTags = report.tags && Array.isArray(report.tags) && 
+                        report.tags.some(tag => 
+                            tag.includes('주간') || 
+                            tag.includes('동향') || 
+                            tag.includes('weekly')
+                        );
+                    
+                    // 주간 동향이 아닌 경우만 심층 분석으로 분류
+                    return !isWeekly && !hasWeeklyTags;
                 });
                 
                 // 날짜순 정렬 (최신순)
                 analysisReports.sort((a, b) => new Date(b.date) - new Date(a.date));
+                
+                console.log('로드된 전체 리포트 수:', allReports.length);
+                console.log('필터링된 심층 분석 리포트 수:', analysisReports.length);
                 
                 // 로딩 스피너 숨기기
                 loadingSpinner.style.display = 'none';

--- a/weekly-report.html
+++ b/weekly-report.html
@@ -711,29 +711,47 @@
             const loadingSpinner = document.getElementById('loadingSpinner');
             
             try {
-                // 파일 기반 로딩 시도
-                let allReports = await loadReportsFromFiles();
+                // JSON 파일을 우선적으로 시도
+                let allReports = await loadReportsFromJSON();
                 
-                // 파일 로딩 실패 시 JSON 폴백
+                // JSON 로딩 실패 시 파일 기반 로딩 시도
                 if (allReports.length === 0) {
-                    allReports = await loadReportsFromJSON();
+                    allReports = await loadReportsFromFiles();
                 }
                 
-                // 주간 동향 리포트만 필터링 - 제목 기준으로 정확하게 필터링
+                // 주간 동향 리포트만 필터링 - 개선된 필터링 로직
                 const weeklyReports = allReports.filter(report => {
                     // type이 weekly로 명시된 경우
                     if (report.type === 'weekly') return true;
                     
-                    // 제목에 "커피 시장 주간 동향"이 포함된 경우
-                    return report.title && (
+                    // 제목에 "주간 동향" 키워드가 포함된 경우
+                    if (report.title && (
+                        report.title.includes('주간 동향') ||
                         report.title.includes('커피 시장 주간 동향') ||
                         report.title.includes('커피 선물 시장 주간 동향') ||
                         report.title === '커피 선물 시장 주간 동향'
-                    );
+                    )) {
+                        return true;
+                    }
+                    
+                    // 태그에 주간 관련 키워드가 있는 경우
+                    if (report.tags && Array.isArray(report.tags)) {
+                        const weeklyTags = report.tags.some(tag => 
+                            tag.includes('주간') || 
+                            tag.includes('동향') || 
+                            tag.includes('weekly')
+                        );
+                        if (weeklyTags) return true;
+                    }
+                    
+                    return false;
                 });
                 
                 // 날짜순 정렬 (최신순)
                 weeklyReports.sort((a, b) => new Date(b.date) - new Date(a.date));
+                
+                console.log('로드된 전체 리포트 수:', allReports.length);
+                console.log('필터링된 주간 리포트 수:', weeklyReports.length);
                 
                 // 로딩 스피너 숨기기
                 loadingSpinner.style.display = 'none';


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix report loading and filtering on weekly and in-depth analysis pages to correctly display reports.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation prioritized file system scanning, which was inefficient and often failed, leading to reports not loading. Additionally, the filtering logic for both weekly and in-depth reports was too narrow, preventing relevant reports from being displayed. This PR switches to prioritizing `reports.json` and enhances the filtering criteria to ensure accurate categorization and display.

---
<a href="https://cursor.com/background-agent?bcId=bc-72e3b399-a9d0-49d1-a166-6304704a4c12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72e3b399-a9d0-49d1-a166-6304704a4c12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>