### PR TITLE
Fix cftc position graph overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,7 @@
             max-width: 1200px;
             margin: 0 auto;
             padding: 20px;
+            overflow-x: hidden;
         }
         
         header {
@@ -724,6 +725,7 @@
             grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
             gap: 30px;
             margin-bottom: 40px;
+            overflow-x: hidden;
         }
         
         .chart-container {
@@ -732,6 +734,8 @@
             padding: 25px;
             box-shadow: 0 8px 25px rgba(0,0,0,0.1);
             transition: transform 0.3s ease;
+            overflow: hidden;
+            max-width: 100%;
         }
         
         .chart-container:hover {
@@ -759,6 +763,7 @@
         .chart-wrapper {
             position: relative;
             height: 400px;
+            overflow: hidden;
         }
         
         .chart-analysis {
@@ -915,6 +920,16 @@
             
             .charts-grid {
                 grid-template-columns: 1fr;
+                gap: 20px;
+            }
+            
+            .chart-container {
+                padding: 20px;
+                margin: 0;
+            }
+            
+            .chart-wrapper {
+                height: 350px;
             }
             
             .reports-grid {
@@ -1985,7 +2000,14 @@
                 const totalData = chartData.length;
                 
                 // 바 차트용 레이블을 모든 데이터 포인트에 대해 생성 (월만 표시)
-                const labels = chartData.map((item) => {
+                // 데이터가 많을 때는 레이블을 간소화
+                const totalData = chartData.length;
+                const shouldSkipLabels = totalData > 20;
+                
+                const labels = chartData.map((item, index) => {
+                    if (shouldSkipLabels && index % Math.ceil(totalData / 15) !== 0 && index !== totalData - 1) {
+                        return '';
+                    }
                     return item.date.toLocaleDateString('ko-KR', { 
                         month: 'short'
                     });
@@ -2003,12 +2025,23 @@
                             data: chartData.map(d => d.y),
                             backgroundColor: chartData.map(point => point.y >= 0 ? '#27AE60' : '#E74C3C'),
                             borderColor: chartData.map(point => point.y >= 0 ? '#229954' : '#C0392B'),
-                            borderWidth: 1
+                            borderWidth: 1,
+                            maxBarThickness: 40,
+                            categoryPercentage: 0.8,
+                            barPercentage: 0.9
                         }]
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
+                        layout: {
+                            padding: {
+                                left: 5,
+                                right: 5,
+                                top: 5,
+                                bottom: 5
+                            }
+                        },
                         interaction: {
                             intersect: false,
                             mode: 'index'
@@ -2043,16 +2076,25 @@
                                     maxRotation: 45,
                                     minRotation: 0,
                                     font: {
-                                        size: isMobile ? 10 : 12
+                                        size: isMobile ? 9 : 11
                                     },
                                     color: '#333',
                                     autoSkip: true,
-                                    maxTicksLimit: 12
+                                    autoSkipPadding: 5,
+                                    maxTicksLimit: isMobile ? 8 : 15,
+                                    callback: function(value, index, values) {
+                                        // 빈 레이블은 표시하지 않음
+                                        if (labels[index] === '') return '';
+                                        return labels[index];
+                                    }
                                 },
                                 grid: {
                                     display: true,
                                     color: 'rgba(0, 0, 0, 0.1)'
-                                }
+                                },
+                                offset: true,
+                                categoryPercentage: 0.8,
+                                barPercentage: 0.9
                             },
                             y: {
                                 title: {


### PR DESCRIPTION
Resolves CFTC position bar chart overflow issue where bars extended beyond the chart area by adjusting container styles, chart options, and X-axis label rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-814df4e0-b3e3-451e-9ee7-283803ed15ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-814df4e0-b3e3-451e-9ee7-283803ed15ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

