### PR TITLE
Hide 2025-08-17.html from weekly report

### DIFF
--- a/weekly-report.html
+++ b/weekly-report.html
@@ -721,6 +721,9 @@
                 
                 // 주간 동향 리포트만 필터링 - 개선된 필터링 로직
                 const weeklyReports = allReports.filter(report => {
+                    // in-depth-analysis 타입은 명시적으로 제외
+                    if (report.type === 'in-depth-analysis' || report.type === 'in-depth') return false;
+                    
                     // type이 weekly로 명시된 경우
                     if (report.type === 'weekly') return true;
                     
@@ -734,11 +737,12 @@
                         return true;
                     }
                     
-                    // 태그에 주간 관련 키워드가 있는 경우
+                    // 태그에 주간 관련 키워드가 있는 경우 (더 구체적으로 필터링)
                     if (report.tags && Array.isArray(report.tags)) {
                         const weeklyTags = report.tags.some(tag => 
                             tag.includes('주간') || 
-                            tag.includes('동향') || 
+                            tag === '동향' || 
+                            tag === '주간동향' ||
                             tag.includes('weekly')
                         );
                         if (weeklyTags) return true;


### PR DESCRIPTION
Exclude in-depth analysis reports from the weekly report by adding an explicit type check and refining tag filtering.

The `2025-08-17.html` report, intended for the in-depth analysis menu, was incorrectly appearing in the weekly report due to its "시장동향" tag. The previous filtering logic broadly included any report with a tag containing "동향", causing this misclassification. The changes ensure that only actual weekly reports are displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-405452da-88c9-4a2e-80db-4dce06cb5711">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-405452da-88c9-4a2e-80db-4dce06cb5711">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

