### PR TITLE
페이지 개선 후 라이브 표시 및 날짜 오류 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,6 +351,9 @@
             gap: 20px;
             flex-wrap: wrap;
             letter-spacing: -0.02em;
+        }
+        
+        .main-title {
             background: linear-gradient(135deg, #ffffff 0%, #e2e8f0 100%);
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
@@ -1071,7 +1074,7 @@
         <div class="container">
             <header>
                 <h1>
-                    Coffee Market Info
+                    <span class="main-title">Coffee Market Info</span>
                     <span class="live-indicator">Live</span>
                     <span class="date-badge" id="currentDate"></span>
                 </h1>


### PR DESCRIPTION
Fix live and date indicators not displaying in the page title.

The `h1` element's `background-clip: text` and `-webkit-text-fill-color: transparent` styles were making its child elements (live and date badges) transparent. These styles are now applied only to the title text via a new `.main-title` class, allowing the badges to render correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c9af03a-58b2-4266-8147-acafc7ff5917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c9af03a-58b2-4266-8147-acafc7ff5917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

